### PR TITLE
Add registry alias from reach entity attributes attack range.

### DIFF
--- a/src/main/java/net/atlas/combatify/mixin/MappedRegistryAccessor.java
+++ b/src/main/java/net/atlas/combatify/mixin/MappedRegistryAccessor.java
@@ -1,0 +1,21 @@
+package net.atlas.combatify.mixin;
+
+import net.minecraft.core.Holder;
+import net.minecraft.core.MappedRegistry;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.Map;
+
+@Mixin(MappedRegistry.class)
+public interface MappedRegistryAccessor<T> {
+
+	@Accessor
+	Map<ResourceLocation, Holder.Reference<T>> getByLocation();
+
+	@Accessor
+	Map<ResourceKey<T>, Holder.Reference<T>> getByKey();
+
+}

--- a/src/main/java/net/atlas/combatify/mixin/ReachEntityAttributesMixin.java
+++ b/src/main/java/net/atlas/combatify/mixin/ReachEntityAttributesMixin.java
@@ -5,6 +5,9 @@ import net.atlas.combatify.item.NewAttributes;
 import net.atlas.combatify.util.CombatUtil;
 import net.atlas.combatify.util.MethodHandler;
 import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
@@ -17,6 +20,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.Objects;
@@ -56,5 +60,16 @@ public class ReachEntityAttributesMixin {
 	@Redirect(method = "onInitialize", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/Registry;register(Lnet/minecraft/core/Registry;Lnet/minecraft/resources/ResourceLocation;Ljava/lang/Object;)Ljava/lang/Object;", ordinal = 1))
 	private <V, T extends V> T disableRegister(Registry<V> registry, ResourceLocation resourceLocation, T object) {
 		return object;
+	}
+	@Inject(method = "onInitialize", at = @At("RETURN"), remap = false)
+	private void addAliasAttackReach(CallbackInfo ci) {
+		var holder = BuiltInRegistries.ATTRIBUTE
+			.getHolderOrThrow(BuiltInRegistries.ATTRIBUTE.getResourceKey(NewAttributes.ATTACK_REACH).orElseThrow());
+		@SuppressWarnings("unchecked")
+		var reg = (MappedRegistryAccessor<Attribute>) BuiltInRegistries.ATTRIBUTE;
+		var loc = new ResourceLocation(ReachEntityAttributes.MOD_ID, "attack_range");
+		var key = ResourceKey.create(Registries.ATTRIBUTE, loc);
+		reg.getByKey().put(key, holder);
+		reg.getByLocation().put(loc, holder);
 	}
 }

--- a/src/main/resources/combatify.mixins.json
+++ b/src/main/resources/combatify.mixins.json
@@ -24,6 +24,7 @@
     "ItemMixin",
     "ItemStackMixin",
     "LivingEntityMixin",
+    "MappedRegistryAccessor",
     "MiscCategoryMixin",
     "MobEffectMixin",
     "MobMixin",


### PR DESCRIPTION
This pull request fixes a crash with any mod that gets the attack reach attribute directly from the registry (for example Kilt).

Basically, it just hacks the registry by adding a reference from "reach-entity-attributes:attack_range" to the combatify attack reach attribute.